### PR TITLE
Add .gitattributes for Godot binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.tscn binary
+*.tres binary
+*.scn binary
+
+# Treat Godot scene and resource files as binary to prevent merge conflicts


### PR DESCRIPTION
Treat Godot scene and resource files as binary to prevent merge conflicts

## Description
What does this PR change?

## Type of Change
- [ ] Develop
- [ ] Bug fix
- [ ] Hotfix
- [ ] Documentation

## Checklist
- [ ] Project runs without errors
- [ ] No new warnings
- [ ] Tested manually
- [ ] Screenshots included (if applicable)
- [ ] Branch name follows convention
